### PR TITLE
fix(security): enforce allowed hosts (defense-in-depth)

### DIFF
--- a/redist/docker-compose.yml
+++ b/redist/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Production
       - Infrastructure__ConnectionString=Host=/var/run/postgresql;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};
       - Kestrel__UnixSocketPath=/var/run/api/sock
+      - AllowedHosts=www.booqr.dk
     restart: unless-stopped
     stop_grace_period: 5s
     security_opt:

--- a/src/Klinkby.Booqr.Api/Program.cs
+++ b/src/Klinkby.Booqr.Api/Program.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Reflection;
 using Klinkby.Booqr.Api;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.HostFiltering;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.OpenApi;
@@ -52,6 +53,20 @@ static void ConfigureServices(WebApplicationBuilder builder, bool isMockServer)
         builder.Services
             .AddSingleton<TimeProvider>(static _ => TimeProvider.System)
             .AddInfrastructure(configuration.GetRequiredSection("Infrastructure"));
+
+        // CreateSlimBuilder omits the default host-filtering startup filter, so wire it
+        // explicitly. The app emits its own authority (e.g. password-reset links) from the
+        // Host header, so constrain it here as defense-in-depth instead of trusting the proxy
+        // alone. An unset or "*" value allows all hosts (dev); production sets the real host.
+        builder.Services.Configure<HostFilteringOptions>(options =>
+        {
+            var allowedHosts = configuration["AllowedHosts"];
+            if (!string.IsNullOrWhiteSpace(allowedHosts) && allowedHosts != "*")
+            {
+                options.AllowedHosts = allowedHosts
+                    .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            }
+        });
         builder.WebHost
             .UseKestrelCore()
             .UseUrls()
@@ -85,6 +100,7 @@ static void ConfigureMiddleware(WebApplication app, bool isMockServer)
         return;
     }
 
+    app.UseHostFiltering();
     app.UseAuthorization();
     app.UseHealthChecks("/api/health");
 

--- a/src/Klinkby.Booqr.Api/appsettings.json
+++ b/src/Klinkby.Booqr.Api/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "AllowedHosts": "*",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/tests/Klinkby.Booqr.Api.Tests/WebApiFixture.cs
+++ b/tests/Klinkby.Booqr.Api.Tests/WebApiFixture.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace Klinkby.Booqr.Api.Tests;
 
-internal sealed class WebApiFixture : WebApplicationFactory<Program>
+internal sealed class WebApiFixture(string? allowedHosts = null) : WebApplicationFactory<Program>
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -35,9 +35,15 @@ internal sealed class WebApiFixture : WebApplicationFactory<Program>
         }
         """;
         using MemoryStream stream = new(Encoding.UTF8.GetBytes(jsonConfig));
-        var configuration = new ConfigurationBuilder()
-            .AddJsonStream(stream)
-            .Build();
+        IConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
+            .AddJsonStream(stream);
+        if (allowedHosts is not null)
+        {
+            configurationBuilder.AddInMemoryCollection(
+                new Dictionary<string, string?> { ["AllowedHosts"] = allowedHosts });
+        }
+
+        IConfigurationRoot configuration = configurationBuilder.Build();
         builder.UseConfiguration(configuration);
         builder.ConfigureAppConfiguration(_ => { });
         builder.ConfigureTestServices(_ => { });

--- a/tests/Klinkby.Booqr.Api.Tests/WebApiServiceTests.cs
+++ b/tests/Klinkby.Booqr.Api.Tests/WebApiServiceTests.cs
@@ -48,4 +48,30 @@ public class WebApiServiceTests
         Assert.Equal(MediaTypeNames.Text.Plain, response.Content.Headers.ContentType!.MediaType);
         Assert.Equal("Healthy", await response.Content.ReadAsStringAsync());
     }
+
+    [Fact]
+    public async Task GIVEN_AllowedHost_WHEN_Request_THEN_Succeeds()
+    {
+        await using WebApiFixture fixture = new("www.booqr.dk");
+        HttpClient client = fixture.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Get, new Uri("/api/health", UriKind.Relative));
+        request.Headers.Host = "www.booqr.dk";
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GIVEN_DisallowedHost_WHEN_Request_THEN_BadRequest()
+    {
+        await using WebApiFixture fixture = new("www.booqr.dk");
+        HttpClient client = fixture.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Get, new Uri("/api/health", UriKind.Relative));
+        request.Headers.Host = "evil.example.com";
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 }


### PR DESCRIPTION
Addresses finding **#8** (A04/A05) from the OWASP review.

## Problem
The app builds its own authority from the `Host` header — `HttpContextExtensions.GetContextAuthority()` is used to construct password-reset and sign-up link base URLs (`Routing.cs:252,308`). Because the app uses `WebApplication.CreateSlimBuilder`, the default host-filtering startup filter is **not** registered, and there is no `AllowedHosts` configured. So a poisoned `Host` header could forge an account-takeover-grade link, with the HAProxy host ACL as the single point of defense.

## Change
- **`Program.cs`** — bind `HostFilteringOptions` from the `AllowedHosts` config value and add `app.UseHostFiltering()` as the first middleware. An unset or `"*"` value allows all hosts; a `;`-delimited list is enforced.
- **`appsettings.json`** — explicit `"AllowedHosts": "*"` as the dev/base default (preserves localhost).
- **`redist/docker-compose.yml`** — production `api1` pins `AllowedHosts=www.booqr.dk`, matching the proxy's `hdr(host) -i www.booqr.dk` ACL and the JWT audience.

## Tests
`WebApiServiceTests` (via `WebApiFixture`, which gains an optional `allowedHosts` parameter; existing `new WebApiFixture()` callers keep allow-all):
- Allowed `Host: www.booqr.dk` → `/api/health` returns **200**.
- Disallowed `Host: evil.example.com` → **400**.

## Notes / scope
- No .NET SDK in the authoring environment, so the suite was **not** run locally — relying on CI.
- The review's secondary sub-point (reset links are emitted as `http://` because TLS terminates at HAProxy and `UseForwardedHeaders` is not configured) is **out of scope** here — happy to handle scheme/forwarded-headers in a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015zCftWwDFaM8CMKkCFQehh)_