### PR TITLE
fix: allow adjacent vacancies at different locations

### DIFF
--- a/src/Klinkby.Booqr.Application/Util/EventExtensions.cs
+++ b/src/Klinkby.Booqr.Application/Util/EventExtensions.cs
@@ -24,7 +24,7 @@ internal static class EventExtensions
     public static bool Contains<TEvent1, TEvent2>(this TEvent1 current, TEvent2 other)
         where TEvent1 : notnull, IEvent
         where TEvent2 : notnull, IEvent =>
-        current.StartTime >= other.StartTime && current.StartTime <= other.EndTime || current.EndTime >= other.StartTime && current.EndTime <= other.EndTime;
+        current.StartTime < other.EndTime && other.StartTime < current.EndTime;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool CompletelyWithin<TEvent1, TEvent2>(this TEvent1 current, TEvent2 other)

--- a/tests/Klinkby.Booqr.Application.Tests/Commands/AddVacancyCommandTests.cs
+++ b/tests/Klinkby.Booqr.Application.Tests/Commands/AddVacancyCommandTests.cs
@@ -50,6 +50,30 @@ public class AddVacancyCommandTests
 
     [Theory]
     [ApplicationAutoData]
+    public async Task GIVEN_AdjacentEventAtOtherLocation_WHEN_AddCalendarEvent_THEN_CreatesNewVacancy(CalendarEvent adjacent)
+    {
+        // Arrange - existing slot at location 2 ends exactly when the request starts
+        adjacent = adjacent with
+        {
+            Id = 501, EmployeeId = _query.EmployeeId ?? 0, LocationId = 2, BookingId = null,
+            StartTime = _query.StartTime.AddHours(-1), EndTime = _query.StartTime
+        };
+        List<CalendarEvent> events = [adjacent];
+        _repoMock.Setup(x => x.Add(It.IsAny<CalendarEvent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(777);
+        var sut = new AddVacancyCommand(_repoMock.Object, _transactionMock.Object,
+            _activityRecorder.Object, NullLogger<AddVacancyCommand>.Instance);
+
+        // Act
+        var result = await sut.AddCalendarEvent(_query, events, _query.EmployeeId ?? 0, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(777, result);
+        _repoMock.Verify(x => x.Add(It.IsAny<CalendarEvent>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [ApplicationAutoData]
     public async Task GIVEN_CompletelyCovered_WHEN_AddCalendarEvent_THEN_ReturnsExistingId(CalendarEvent coveringEvent)
     {
         // Arrange


### PR DESCRIPTION
## Summary
- `Contains()` in `EventExtensions.cs` used inclusive boundary comparisons, so a new vacancy touching (but not overlapping) an existing one at a different location was wrongly treated as a location conflict, causing a 409.
- Changed to strict half-open interval overlap semantics (`current.Start < other.End && other.Start < current.End`), so adjacent slots are no longer false positives while genuine overlaps are still rejected.
- `Contains` has a single caller (`AddVacancyCommand.TryGetEventWithConflictingLocation`), so blast radius is limited. Same-employee, same-location adjacent-slot merging is driven by `StartIntersects`/`TryExtendEnd`/`TryExtendStart`, not `Contains`, and is unaffected.

Fixes #231

## Test plan
- [x] Added `GIVEN_AdjacentEventAtOtherLocation_WHEN_AddCalendarEvent_THEN_CreatesNewVacancy`; confirmed it fails against the pre-fix logic (reproducing the reported 409) and passes with the fix.
- [x] Full `Klinkby.Booqr.Application.Tests` suite passes (157/157), including existing genuine cross-location overlap and same-location adjacent-merge tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)