### PR TITLE
Return application/problem+json for unhandled exceptions

### DIFF
--- a/src/Klinkby.Booqr.Api/GlobalExceptionHandler.cs
+++ b/src/Klinkby.Booqr.Api/GlobalExceptionHandler.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace Klinkby.Booqr.Api;
+
+/// <summary>
+///     Converts any unhandled exception into an RFC 7807 Problem Details response, always emitting
+///     <c>application/problem+json</c> regardless of the request's <c>Accept</c> header. The status
+///     code is chosen by <see cref="StatusCode.FromException" />.
+/// </summary>
+internal sealed class GlobalExceptionHandler(IProblemDetailsService problemDetailsService) : IExceptionHandler
+{
+    private const string ProblemJsonContentType = "application/problem+json";
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+    {
+        var status = StatusCode.FromException(exception);
+        httpContext.Response.StatusCode = status;
+
+        ProblemDetails problem = new()
+        {
+            Status = status,
+            Title = ReasonPhrases.GetReasonPhrase(status)
+        };
+
+        // Common path: honours content negotiation and the central CustomizeProblemDetails (traceId) hook.
+        if (await problemDetailsService.TryWriteAsync(new ProblemDetailsContext
+            {
+                HttpContext = httpContext,
+                ProblemDetails = problem
+            }))
+        {
+            return true;
+        }
+
+        // Fallback: the writer declined (e.g. Accept: text/html). Force problem+json AOT-safely,
+        // re-adding the traceId extension the customization would otherwise have supplied.
+        problem.Extensions["traceId"] = httpContext.TraceIdentifier;
+        await httpContext.Response.WriteAsJsonAsync(
+            problem,
+            AppJsonSerializerContext.Default.ProblemDetails,
+            ProblemJsonContentType,
+            cancellationToken);
+        return true;
+    }
+}

--- a/src/Klinkby.Booqr.Api/Program.cs
+++ b/src/Klinkby.Booqr.Api/Program.cs
@@ -110,11 +110,7 @@ static void ConfigureMiddleware(WebApplication app, bool isMockServer)
     }
     else
     {
-        app.UseExceptionHandler(new ExceptionHandlerOptions
-        {
-            AllowStatusCode404Response = true,
-            StatusCodeSelector = StatusCode.FromException
-        });
+        app.UseExceptionHandler(new ExceptionHandlerOptions { AllowStatusCode404Response = true });
     }
 
     app.UseSecurityHeaders();

--- a/src/Klinkby.Booqr.Api/ServiceCollectionExtensions.cs
+++ b/src/Klinkby.Booqr.Api/ServiceCollectionExtensions.cs
@@ -52,6 +52,7 @@ internal static class ServiceCollectionExtensions
         services.AddProblemDetails(static options =>
             options.CustomizeProblemDetails = static context =>
                 context.ProblemDetails.Extensions["traceId"] = context.HttpContext.TraceIdentifier);
+        services.AddExceptionHandler<Klinkby.Booqr.Api.GlobalExceptionHandler>();
     }
 
     private static void ConfigureHealthChecks(IServiceCollection services)

--- a/tests/Klinkby.Booqr.Api.Tests/GlobalExceptionHandlerTests.cs
+++ b/tests/Klinkby.Booqr.Api.Tests/GlobalExceptionHandlerTests.cs
@@ -1,0 +1,50 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Klinkby.Booqr.Api.Tests;
+
+public class GlobalExceptionHandlerTests
+{
+    private static readonly Uri ThrowUri = new("api/test-throw", UriKind.Relative);
+
+    [Fact]
+    public async Task GIVEN_UnhandledException_WHEN_RequestingEndpoint_THEN_ReturnsProblemJson()
+    {
+        await using WebApiFixture fixture = new(withThrowingEndpoint: true);
+        HttpClient client = fixture.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(ThrowUri);
+
+        Assert.Equal(HttpStatusCode.GatewayTimeout, response.StatusCode);
+        Assert.Equal(MediaTypeNames.Application.ProblemJson, response.Content.Headers.ContentType!.MediaType);
+
+        ProblemDetails? problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal((int)HttpStatusCode.GatewayTimeout, problem.Status);
+        Assert.True(problem.Extensions.ContainsKey("traceId"));
+    }
+
+    [Fact]
+    public async Task GIVEN_UnhandledExceptionAndHtmlAccept_WHEN_RequestingEndpoint_THEN_StillReturnsProblemJson()
+    {
+        await using WebApiFixture fixture = new(withThrowingEndpoint: true);
+        HttpClient client = fixture.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Get, ThrowUri);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Text.Html));
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        // The content type must be forced regardless of the Accept header (the regression guard
+        // versus content-negotiated exception bodies).
+        Assert.Equal(HttpStatusCode.GatewayTimeout, response.StatusCode);
+        Assert.Equal(MediaTypeNames.Application.ProblemJson, response.Content.Headers.ContentType!.MediaType);
+
+        ProblemDetails? problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal((int)HttpStatusCode.GatewayTimeout, problem.Status);
+        Assert.True(problem.Extensions.ContainsKey("traceId"));
+    }
+}

--- a/tests/Klinkby.Booqr.Api.Tests/WebApiFixture.cs
+++ b/tests/Klinkby.Booqr.Api.Tests/WebApiFixture.cs
@@ -1,13 +1,16 @@
 ﻿using System.Text;
 using System.Text.Unicode;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Klinkby.Booqr.Api.Tests;
 
-internal sealed class WebApiFixture(string? allowedHosts = null) : WebApplicationFactory<Program>
+internal sealed class WebApiFixture(string? allowedHosts = null, bool withThrowingEndpoint = false)
+    : WebApplicationFactory<Program>
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -46,6 +49,33 @@ internal sealed class WebApiFixture(string? allowedHosts = null) : WebApplicatio
         IConfigurationRoot configuration = configurationBuilder.Build();
         builder.UseConfiguration(configuration);
         builder.ConfigureAppConfiguration(_ => { });
-        builder.ConfigureTestServices(_ => { });
+
+        if (withThrowingEndpoint)
+        {
+            // Force the non-Development branch so GlobalExceptionHandler (not the developer
+            // exception page) handles the throw, regardless of the ambient environment.
+            builder.UseEnvironment("Production");
+            builder.ConfigureTestServices(static services =>
+                services.AddSingleton<IStartupFilter, ThrowingStartupFilter>());
+        }
+        else
+        {
+            builder.ConfigureTestServices(_ => { });
+        }
+    }
+
+    /// <summary>
+    ///     Appends a terminal middleware that always throws, placed <em>after</em> the application
+    ///     pipeline so it runs downstream of <c>UseExceptionHandler</c>. Any unmatched request (e.g.
+    ///     <c>GET /api/test-throw</c>) reaches it and surfaces an unhandled exception through the
+    ///     real pipeline.
+    /// </summary>
+    private sealed class ThrowingStartupFilter : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => app =>
+        {
+            next(app);
+            app.Run(static _ => throw new TimeoutException("Simulated unhandled exception"));
+        };
     }
 }


### PR DESCRIPTION
Replace the UseExceptionHandler StatusCodeSelector delegate with a generic
IExceptionHandler (GlobalExceptionHandler) that maps unhandled exceptions to a
status code via the existing StatusCode.FromException and always writes an
RFC 7807 Problem Details body with content type application/problem+json.

The previous StatusCodeSelector-only setup left the body to the framework's
IProblemDetailsService, which negotiates on the Accept header and writes nothing
for non-JSON clients (e.g. Accept: text/html) — so error responses were not
guaranteed to be problem+json. The handler now forces problem+json: it first
tries IProblemDetailsService (preserving the central traceId customization) and,
if content negotiation declines, falls back to writing the ProblemDetails
directly and AOT-safely via AppJsonSerializerContext.

Adds integration tests driving a real unhandled exception through the pipeline
and asserting the mapped status code plus application/problem+json, including
when the client sends Accept: text/html.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B24MrYssBG17zPdUMNY88i