### PR TITLE
fix: annotate MapResult generic for AOT trim analysis

### DIFF
--- a/src/Klinkby.Booqr.Api/Util/CommandExtensions.cs
+++ b/src/Klinkby.Booqr.Api/Util/CommandExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Klinkby.Booqr.Application;
 using Microsoft.AspNetCore.Http.HttpResults;
 
@@ -16,7 +17,10 @@ internal static class CommandExtensions
         internal ValueTask<Results<Ok<T>, ProblemHttpResult>> ToOk() =>
             ToOk<T, T>(commandResult, x => x);
 
-        private async ValueTask<Results<U, ProblemHttpResult>> MapResult<U>(Func<T, U> mapSuccess) where U : IResult =>
+        private async ValueTask<Results<U, ProblemHttpResult>> MapResult<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods |
+                                        DynamicallyAccessedMemberTypes.NonPublicMethods)] U>(
+            Func<T, U> mapSuccess) where U : IResult =>
             await commandResult switch
             {
                 Result<T>.Success s => mapSuccess(s.Value),


### PR DESCRIPTION
## Problem

The last `main` build failed in the **Build and Push Docker image** workflow ([run 28735270371](https://github.com/klinkby/booqr/actions/runs/28735270371)). The native AOT compilation (ILC) aborted with trim-analysis error **IL2091**, repeated across `CommandExtensions.MapResult<T,U>`:

```
ILC : Trim analysis error IL2091:
Klinkby.Booqr.Api.Util.CommandExtensions.MapResult<T,U>(...):
'TResult1' generic argument does not satisfy
'DynamicallyAccessedMemberTypes.PublicMethods',
'DynamicallyAccessedMemberTypes.NonPublicMethods'
in 'Microsoft.AspNetCore.Http.HttpResults.Results`2'.
```

`Results<TResult1, TResult2>` annotates its type parameters with `[DynamicallyAccessedMembers(PublicMethods | NonPublicMethods)]`, but the generic parameter `U` of `MapResult<U>` was passed into that `TResult1` slot without a matching annotation, so the trimmer could not guarantee the required members would survive.

The `Run Tests` workflow on the same commit passed because unit-test builds don't run the ILC trimmer — the break only surfaced in the AOT Docker publish. Introduced by #233 (*refactor: unions over exceptions*).

## Fix

Add the matching `[DynamicallyAccessedMembers(PublicMethods | NonPublicMethods)]` annotation to the `U` generic parameter of `MapResult<U>` in `src/Klinkby.Booqr.Api/Util/CommandExtensions.cs`. All `ToOk`/`ToCreated`/`ToNoContent` mappers funnel through this method, so the single annotation covers every call site.

## Verification

No .NET SDK is available in this environment, so the native AOT publish could not be run locally — the `Build and Push Docker image` CI workflow verifies the fix (the ILC step must complete without IL2091).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cGM5gTPocV3cgQBwwNsc4

---
_Generated by [Claude Code](https://claude.ai/code/session_019cGM5gTPocV3cgQBwwNsc4)_