### PR TITLE
Fix canonicalize percent-encoding

### DIFF
--- a/redist/.env.example
+++ b/redist/.env.example
@@ -1,6 +1,7 @@
 # api config
 Kestrel__Certificates__Default__Password=cbf535fbbdba...fa15a2b38a
 Application__Jwt__Key=fa15a2b38a...cbf535fbbdba
+Application__Password__HmacKey=fa15a2b38a...cbf535fbbdba
 
 # db config
 POSTGRES_DB=booqr

--- a/redist/docker-compose.yml
+++ b/redist/docker-compose.yml
@@ -1,57 +1,55 @@
+
 services:
   app:
-    image: 'klinkby/booqr-app:107'
+    image: klinkby/booqr-app:409
     read_only: true
     tmpfs:
-      - '/tmp:mode=1777,noexec,nosuid'
+      - /tmp:mode=1777,noexec,nosuid
     volumes:
-      - 'app-sock:/var/run/lighttpd'
+      - ./app_sock:/var/run/lighttpd
     cap_drop:
       - ALL
     security_opt:
-      - 'no-new-privileges:true'
+      - no-new-privileges:true
+    network_mode: none
     restart: unless-stopped
     healthcheck:
-      test:
-        - CMD-SHELL
-        - test -S /var/run/lighttpd/sock
+      test: [ "CMD-SHELL", "test -S /var/run/lighttpd/sock" ]
       interval: 10s
       timeout: 5s
       retries: 5
     deploy:
       resources:
         limits:
-          cpus: '1.0'
-          memory: 64M
+          cpus: "1.0"
+          memory: "64M"
         reservations:
-          memory: 16M
-          cpus: '0.1'
+          memory: "16M"
+          cpus: "0.1"
+
   api1:
-    image: 'klinkby/booqr:88'
+    image: klinkby/booqr:178
     env_file:
       - ./.env
     networks:
       - service-net
     read_only: true
     volumes:
-      - 'postgres_socket:/var/run/postgresql'
-      - './api_sock:/var/run/api'
+      - postgres_socket:/var/run/postgresql
+      - ./api_sock:/var/run/api
     tmpfs:
-      - '/tmp:mode=1777,noexec,nosuid'
+      - /tmp:mode=1777,noexec,nosuid
       - /home/app/.aspnet/DataProtection-Keys
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
-      - Infrastructure__ConnectionString=Host=/var/run/postgresql;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};
+      - Infrastructure__ConnectionString=Host=/var/run/postgresql;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
       - Kestrel__UnixSocketPath=/var/run/api/sock
-      - AllowedHosts=www.booqr.dk
     restart: unless-stopped
     stop_grace_period: 5s
     security_opt:
-      - 'no-new-privileges:true'
+      - no-new-privileges:true
     healthcheck:
-      test:
-        - CMD-SHELL
-        - test -S /var/run/api/sock
+      test: [ "CMD-SHELL", "test -S /var/run/api/sock" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -63,30 +61,30 @@ services:
         reservations:
           memory: 32M
           cpus: '0.1'
+
   postgres:
-    image: 'postgres:18-alpine3.23'
+    image: postgres:18-alpine3.23
     environment:
       - INSTANCE_UNIX_SOCKET=/var/run/postgresql
-      - 'POSTGRES_DB=${POSTGRES_DB}'
-      - 'POSTGRES_USER=${POSTGRES_USER}'
-      - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_HOST_AUTH_METHOD=scram-sha-256
     read_only: true
     volumes:
-      - '/mnt/postgres-hel1-1/booqr:/var/lib/postgresql/18/docker'
-      - './initdb.sql:/docker-entrypoint-initdb.d/DDL.sql:ro'
-      - 'postgres_socket:/var/run/postgresql'
+      - /mnt/postgres-hel1-1/booqr:/var/lib/postgresql/18/docker
+      - ./initdb:/docker-entrypoint-initdb.d:ro
+      - postgres_socket:/var/run/postgresql
     tmpfs:
-      - '/tmp:mode=1777,noexec,nosuid'
+      - "/tmp:mode=1777,noexec,nosuid"
     network_mode: none
     restart: unless-stopped
     stop_grace_period: 30s
+
     security_opt:
-      - 'no-new-privileges:true'
+      - no-new-privileges:true
     healthcheck:
-      test:
-        - CMD-SHELL
-        - 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -98,27 +96,34 @@ services:
         reservations:
           memory: 64M
           cpus: '0.25'
+
   proxy:
     ports:
       - '80:8080/tcp'
       - '443:8443/tcp'
       - '443:8443/udp'
-    image: 'haproxytech/haproxy-alpine:3.4.1'
+    image: haproxytech/haproxy-alpine:3.4.1
     volumes:
-      - './web-gateway/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro'
-      - '/root/certs.pem:/etc/ssl/certs/certs.pem:ro'
-      - 'booqr_socket:/var/run/booqr'
-      - 'app_socket:/var/run/app'
+      - ./web-gateway/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+      - /root/certs.pem:/etc/ssl/certs/certs.pem:ro
+      - ./api_sock:/run/api
+      - ./app_sock:/run/app
+      - ./kli_sock:/run/kli
     networks:
       - gateway-net
     env_file:
       - ./web-gateway/gateway.env
     tmpfs:
-      - '/tmp:mode=1777,noexec,nosuid'
+      - /tmp:mode=1777,noexec,nosuid
     restart: unless-stopped
     read_only: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+      - NET_RAW
     security_opt:
-      - 'no-new-privileges:true'
+      - no-new-privileges:true
     stop_grace_period: 5s
     deploy:
       resources:
@@ -129,16 +134,14 @@ services:
           memory: 64M
           cpus: '0.1'
     healthcheck:
-      test:
-        - CMD-SHELL
-        - 'wget -qO- http://127.0.0.1:8080/health'
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:8080/health" ]
       interval: 10s
       timeout: 5s
       retries: 5
+
 volumes:
-  postgres_socket: null
-  booqr_socket: null
-  app_socket: null
+  postgres_socket:
+
 networks:
-  service-net: null
-  gateway-net: null
+  service-net:
+  gateway-net:

--- a/redist/web-gateway/haproxy.cfg
+++ b/redist/web-gateway/haproxy.cfg
@@ -26,6 +26,14 @@ frontend http-8080
     stick-table type ip size 10k expire 30s store http_req_rate(10s)
     http-request track-sc0 src
     http-request deny if { sc_http_req_rate(0) gt 10 }
+    # Ignore spam (thanks https://github.com/elabftw/elabftw/blob/34bc143bd37a79a8d4d3c3bda395417f7c8cceeb/documentation/config_examples/haproxy/acl-evil.lst)
+    acl evil_path path_reg -i ^/[0-9a-zA-Z_-]{1,10}\.php$
+    acl evil_path path_reg -i (admin|config|setup|install|backup|\.sql$|\.env$|\.git|vendor|cgi-bin|console|manager)
+    acl evil_path path_reg -i (pma|mysql)
+    acl evil_path path_reg -i (wp-content|wp-includes|wordpress|xmlrpc\.php|wlwmanifest\.xml|/wp[0-9]?/)
+    acl evil_path path_reg -i (actuator|ignition|thinkphp|solr|jenkins|shell|hack\.php|cmd\.php|%[0-9A-Fa-f]{2}|\.htm$|\.tpl$)
+    http-request set-log-level silent if evil_path
+    http-request silent-drop if evil_path
     # Block suspicious requests
     acl valid_methods method GET HEAD OPTIONS
     acl large_request hdr_val(content-length) gt 65536
@@ -38,7 +46,7 @@ frontend http-8080
     acl is_acme path_beg /.well-known/acme-challenge
     http-request return status 200 content-type "text/plain" lf-string "%[path,regsub(/.well-known/acme-challenge/,,g)].%[env(ACCOUNT_THUMBPRINT)]" if is_acme
     # Otherwise
-    redirect scheme https code 301 unless is_health || is_acme
+    redirect scheme https code 301 unless is_acme || is_health
 
 frontend https-8443
     log     global
@@ -53,6 +61,14 @@ frontend https-8443
     stick-table type ip size 10k expire 30s store http_req_rate(10s)
     http-request track-sc0 src
     http-request deny if { sc_http_req_rate(0) gt 50 }
+    # Ignore spam (thanks https://github.com/elabftw/elabftw/blob/34bc143bd37a79a8d4d3c3bda395417f7c8cceeb/documentation/config_examples/haproxy/acl-evil.lst)
+    acl evil_path path_reg -i ^/[0-9a-zA-Z_-]{1,10}\.php$
+    acl evil_path path_reg -i (admin|config|setup|install|backup|\.sql$|\.env$|\.git|vendor|cgi-bin|console|manager)
+    acl evil_path path_reg -i (pma|mysql)
+    acl evil_path path_reg -i (wp-content|wp-includes|wordpress|xmlrpc\.php|wlwmanifest\.xml|/wp[0-9]?/)
+    acl evil_path path_reg -i (actuator|ignition|thinkphp|solr|jenkins|shell|hack\.php|cmd\.php|%[0-9A-Fa-f]{2}|\.htm$|\.tpl$)
+    http-request set-log-level silent if evil_path
+    http-request silent-drop if evil_path
     # Block suspicious requests
     acl valid_methods method GET POST PUT DELETE PATCH HEAD OPTIONS
     acl large_request hdr_val(content-length) gt 1048576
@@ -71,8 +87,12 @@ backend deny
 
 backend api
     http-request replace-uri ^https(://.*)$ http\1
-    server api1 /run/api/sock proto h2
+    server api1 /run/api/sock proto h2 check
 
 backend app
+    filter comp-res
+    compression algo gzip
+    compression type text/css text/html text/javascript text/plain
+    compression offload
     http-request replace-uri ^https(://.*)$ http\1
-    server app /run/app/sock proto h2
+    server app /run/app/sock proto h2 check

--- a/src/Klinkby.Booqr.Application/ExpiringQueryString.cs
+++ b/src/Klinkby.Booqr.Application/ExpiringQueryString.cs
@@ -110,14 +110,57 @@ internal sealed class ExpiringQueryString(
 
     private string HashAndEncodeToBase64Url(string text)
     {
-        // Sign the exact bytes. Do NOT normalize case: upper-casing here would make
-        // the MAC case-insensitive, so two query strings differing only by case would
-        // share a signature and integrity could be bypassed for any case-sensitive value.
+        // Sign the exact bytes, apart from percent-encoding case. Do NOT upper-case the whole
+        // text: that would make the MAC case-insensitive, so two query strings differing only by
+        // case would share a signature and integrity could be bypassed for any case-sensitive
+        // value. Canonicalizing only the hex digits of %XY triplets keeps every value's case
+        // bound while surviving RFC 3986 normalization in transit.
         var hashBytes = HMACSHA3_384.HashData(
             Convert.FromBase64String(_hmacKey),
-            Encoding.UTF8.GetBytes(text));
+            Encoding.UTF8.GetBytes(CanonicalizePercentEncoding(text)));
         var hashValue = Base64Url.EncodeToString(hashBytes);
         return hashValue;
+    }
+
+    /// <summary>
+    ///     Upper-cases the two hex digits of every well-formed %XY triplet, leaving everything
+    ///     else untouched.
+    /// </summary>
+    /// <remarks>
+    ///     RFC 3986 §6.2.2.1 defines percent-encoding as case-insensitive and has normalizers
+    ///     upper-case the triplets, while <see cref="HttpUtility.UrlEncode(string)" /> emits them
+    ///     in lower case ("%3a"). Mail clients, link rewriters and front-ends that re-serialize
+    ///     the query therefore hand back "%3A" for the very bytes we signed. Signing the
+    ///     canonical form makes the MAC stable across that rewrite without weakening it:
+    ///     <see cref="HttpUtility.ParseQueryString(string)" /> already decodes both spellings to
+    ///     the same character, so they were never distinguishable to the consumer.
+    /// </remarks>
+    private static string CanonicalizePercentEncoding(string text)
+    {
+        if (!text.Contains('%', StringComparison.Ordinal))
+        {
+            return text;
+        }
+
+        return string.Create(text.Length, text, static (span, source) =>
+        {
+            source.CopyTo(span);
+            for (var i = 0; i <= span.Length - 3; i++)
+            {
+                if (span[i] != '%'
+                    || !char.IsAsciiHexDigit(span[i + 1])
+                    || !char.IsAsciiHexDigit(span[i + 2]))
+                {
+                    continue;
+                }
+
+                span[i + 1] = char.ToUpperInvariant(span[i + 1]);
+                span[i + 2] = char.ToUpperInvariant(span[i + 2]);
+                // Skip past the triplet so an encoded percent ("%253a") only has its own
+                // "25" normalized — the trailing "3a" is literal payload on both sides.
+                i += 2;
+            }
+        });
     }
 }
 

--- a/tests/Klinkby.Booqr.Application.Tests/ExpiringQueryStringTests.cs
+++ b/tests/Klinkby.Booqr.Application.Tests/ExpiringQueryStringTests.cs
@@ -109,6 +109,65 @@ public class ExpiringQueryStringTests
         Assert.Equal(QueryStringValidation.IntegrityFailed, status);
     }
 
+    [Fact]
+    public void BuildAndValidate_ShouldReturnTrue_ForUppercasedPercentTriplets()
+    {
+        // Arrange
+        ExpiringQueryString sut = new(PasswordSettings, _timeProvider);
+
+        // Act — HttpUtility.UrlEncode emits lower-case triplets, but RFC 3986 §6.2.2.1 lets any
+        // intermediary (mail client, link rewriter, front-end re-encoding the query) upper-case
+        // them. That rewrite must not break integrity.
+        var queryString = sut.Create(TimeSpan.FromHours(1));
+        Assert.Contains("%3a", queryString, StringComparison.Ordinal);
+        var rewritten = queryString.Replace("%3a", "%3A", StringComparison.Ordinal);
+        var isValid = sut.TryParse(rewritten, out NameValueCollection? _, out QueryStringValidation status);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Equal(QueryStringValidation.Success, status);
+    }
+
+    [Theory]
+    [InlineData("jane doe+test@example.com")]
+    [InlineData("100%25 sure")]
+    [InlineData("a:b/c?d&e=f")]
+    public void BuildAndValidate_ShouldReturnTrue_ForUppercasedPercentTripletsInParameterValue(string value)
+    {
+        // Arrange
+        ExpiringQueryString sut = new(PasswordSettings, _timeProvider);
+        NameValueCollection parameters = new() { { "value", value } };
+
+        // Act — upper-case every triplet the way a normalizer would, including the "%25" of an
+        // encoded percent sign, whose trailing literal characters must stay untouched.
+        var queryString = sut.Create(TimeSpan.FromHours(1), parameters);
+        var rewritten = UppercasePercentTriplets(queryString);
+        var isValid = sut.TryParse(rewritten, out NameValueCollection? outParameters, out QueryStringValidation status);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Equal(QueryStringValidation.Success, status);
+        Assert.Equal(value, outParameters!["value"]);
+    }
+
+    private static string UppercasePercentTriplets(string text)
+    {
+        var chars = text.ToCharArray();
+        for (var i = 0; i <= chars.Length - 3; i++)
+        {
+            if (chars[i] != '%' || !char.IsAsciiHexDigit(chars[i + 1]) || !char.IsAsciiHexDigit(chars[i + 2]))
+            {
+                continue;
+            }
+
+            chars[i + 1] = char.ToUpperInvariant(chars[i + 1]);
+            chars[i + 2] = char.ToUpperInvariant(chars[i + 2]);
+            i += 2;
+        }
+
+        return new string(chars);
+    }
+
     [Theory]
     [InlineData("&hash=invalidhash")]
     [InlineData("&hash=")]


### PR DESCRIPTION
```
### Summary

This pull request contains the following changes:
- Fixed canonicalization of percent-encoding to ensure stable query signatures.
also:
- Added an example `.env` file to assist with environment configuration.
- Implemented a filter to block spam requests in the proxy.
```