### PR TITLE
Fix AddBookingCommand to use NewBooking template instead of Reminder

### DIFF
--- a/src/Klinkby.Booqr.Application/Commands/Bookings/AddBookingCommand.cs
+++ b/src/Klinkby.Booqr.Application/Commands/Bookings/AddBookingCommand.cs
@@ -206,7 +206,7 @@ public partial class AddBookingCommand(
 
     private static Message ComposeMessage(BookingDetails booking)
     {
-        return EmbeddedResource.Properties_Reminder_handlebars.ComposeMessage(
+        return EmbeddedResource.Properties_NewBooking_handlebars.ComposeMessage(
             booking.CustomerEmail,
             StringResources.NewBooking,
             new Dictionary<string, string>


### PR DESCRIPTION
## Summary

`AddBookingCommand.ComposeMessage` composed the new-booking confirmation email using the `Reminder.handlebars` template (the "husk din tid ... i morgen" day-before-reminder wording used by `ReminderMailService`), even though it already passed `StringResources.NewBooking` as the subject.

There is a dedicated `NewBooking.handlebars` template with the correct "Tak for din bestilling" (thanks for your booking) wording, but it wasn't being referenced.

## Change

- `AddBookingCommand.cs`: use `EmbeddedResource.Properties_NewBooking_handlebars` instead of `EmbeddedResource.Properties_Reminder_handlebars` when composing the new-booking confirmation message, matching the source-generator's naming convention (`Properties\*.handlebars` → `Properties_<Name>_handlebars`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01V952Gd4voJQ58vCED4GcwH)_