### PR TITLE
Harden HAProxy container runtime

### DIFF
--- a/redist/docker-compose.yml
+++ b/redist/docker-compose.yml
@@ -98,6 +98,7 @@ services:
           cpus: '0.25'
 
   proxy:
+    user: haproxy
     ports:
       - '80:8080/tcp'
       - '443:8443/tcp'
@@ -119,9 +120,6 @@ services:
     read_only: true
     cap_drop:
       - ALL
-    cap_add:
-      - NET_BIND_SERVICE
-      - NET_RAW
     security_opt:
       - no-new-privileges:true
     stop_grace_period: 5s

--- a/redist/web-gateway/haproxy.cfg
+++ b/redist/web-gateway/haproxy.cfg
@@ -34,7 +34,7 @@ frontend http-8080
     acl evil_path path_reg -i (actuator|ignition|thinkphp|solr|jenkins|shell|hack\.php|cmd\.php|%[0-9A-Fa-f]{2}|\.htm$|\.tpl$)
     acl is_post_path path_beg -i /post/
     http-request set-log-level silent if evil_path !is_post_path
-    http-request silent-drop if evil_path !is_post_path
+    http-request silent-drop rst-ttl 1 if evil_path !is_post_path
     # Block suspicious requests
     acl valid_methods method GET HEAD OPTIONS
     acl large_request hdr_val(content-length) gt 65536
@@ -70,7 +70,7 @@ frontend https-8443
     acl evil_path path_reg -i (actuator|ignition|thinkphp|solr|jenkins|shell|hack\.php|cmd\.php|%[0-9A-Fa-f]{2}|\.htm$|\.tpl$)
     acl is_post_path path_beg -i /post/
     http-request set-log-level silent if evil_path !is_post_path
-    http-request silent-drop if evil_path !is_post_path
+    http-request silent-drop rst-ttl 1 if evil_path !is_post_path
     # Block suspicious requests
     acl valid_methods method GET POST PUT DELETE PATCH HEAD OPTIONS
     acl large_request hdr_val(content-length) gt 1048576


### PR DESCRIPTION
## Summary
- run HAProxy as the image-provided `haproxy` user
- remove unnecessary `NET_BIND_SERVICE` and `NET_RAW` capabilities
- use explicit `silent-drop rst-ttl 1`, which does not require TCP_REPAIR privileges

## Validation
- `git diff --check` passed
- HAProxy config should be checked with the target image before merge: `docker compose run --rm --no-deps proxy haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg`