### PR TITLE
fix: support HEAD method on /api/health endpoint

### DIFF
--- a/src/Klinkby.Booqr.Api/Program.cs
+++ b/src/Klinkby.Booqr.Api/Program.cs
@@ -102,7 +102,6 @@ static void ConfigureMiddleware(WebApplication app, bool isMockServer)
 
     app.UseHostFiltering();
     app.UseAuthorization();
-    app.UseHealthChecks("/api/health");
 
     if (app.Environment.IsDevelopment())
     {
@@ -119,6 +118,7 @@ static void ConfigureMiddleware(WebApplication app, bool isMockServer)
 static void ConfigureEndpoints(WebApplication app)
 {
     app.UseStatusCodePages();
+    app.MapHealthChecks("/api/health");
     app.MapApiRoutes();
 }
 

--- a/tests/Klinkby.Booqr.Api.Tests/WebApiServiceTests.cs
+++ b/tests/Klinkby.Booqr.Api.Tests/WebApiServiceTests.cs
@@ -50,6 +50,18 @@ public class WebApiServiceTests
     }
 
     [Fact]
+    public async Task GIVEN_HealthHeadRequest_THEN_Succeeds()
+    {
+        await using WebApiFixture fixture = new();
+        HttpClient client = fixture.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Head, new Uri("/api/health", UriKind.Relative));
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
     public async Task GIVEN_AllowedHost_WHEN_Request_THEN_Succeeds()
     {
         await using WebApiFixture fixture = new("www.booqr.dk");


### PR DESCRIPTION
Replace UseHealthChecks (middleware, GET-only) with MapHealthChecks
(endpoint routing, GET+HEAD) so that HEAD requests return 200 instead
of falling through to a 404.

Move the health check registration from ConfigureMiddleware into
ConfigureEndpoints where endpoint-routing calls belong.

Add a test verifying HEAD /api/health returns 200 OK.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RwHZosgggX8Yqi3ffQ8uPj